### PR TITLE
Support the RubyMine IDE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ doc/
 
 # Ignore Redis dumps
 *.rdb
+
+# RubyMine IDE files
+.idea/


### PR DESCRIPTION
This trivially minor branch lets Git ignore the `.idea/` directory, which is where the RubyMine IDE stores its files.