### PR TITLE
Dan/update url generation

### DIFF
--- a/app/controllers/api/v1/extension_uploads_controller.rb
+++ b/app/controllers/api/v1/extension_uploads_controller.rb
@@ -87,8 +87,9 @@ class Api::V1::ExtensionUploadsController < Api::V1Controller
       error({}, 403)
     else
       @latest_extension_version_url = api_v1_extension_version_url(
-        @extension, @extension.latest_extension_version
-      )
+        @extension,
+        @extension.latest_extension_version,
+        username:     @extension.owner_name)
 
       @extension.destroy
 

--- a/app/controllers/api/v1/extensions_controller.rb
+++ b/app/controllers/api/v1/extensions_controller.rb
@@ -40,7 +40,10 @@ class Api::V1::ExtensionsController < Api::V1Controller
   #
   def show
     @extension_versions_urls = @extension.sorted_extension_versions.map do |version|
-      api_v1_extension_version_url(@extension, version)
+      api_v1_extension_version_url(
+        @extension,
+        version,
+        username: @extension.owner_name)
     end
   end
 

--- a/app/controllers/collaborators_controller.rb
+++ b/app/controllers/collaborators_controller.rb
@@ -48,7 +48,7 @@ class CollaboratorsController < ApplicationController
         CollaboratorMailer.delay.added_email(collaborator)
       end
 
-      redirect_to resource, notice: t('collaborator.added')
+      redirect_to helpers.collaboration_url(resource), notice: t('collaborator.added')
     else
       not_found!
     end

--- a/app/controllers/extension_versions_controller.rb
+++ b/app/controllers/extension_versions_controller.rb
@@ -44,7 +44,7 @@ class ExtensionVersionsController < ApplicationController
       @version.save
     end
 
-    redirect_to({ action: :show }.merge(params.slice(:extension_id, :version)))
+    redirect_to({ action: :show }.merge(params.slice(:username, :extension_id, :version)))
   end
 
   private

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -218,7 +218,7 @@ class ExtensionsController < ApplicationController
       ExtensionDeprecatedNotifier.perform_async(@extension.id)
 
       redirect_to(
-        @extension,
+        owner_scoped_extension_url(@extension),
         notice: t(
           'extension.deprecated',
           extension: @extension.name,
@@ -241,7 +241,7 @@ class ExtensionsController < ApplicationController
     @extension.update_attributes(deprecated: false, replacement: nil)
 
     redirect_to(
-      @extension,
+      owner_scoped_extension_url(@extension),
       notice: t(
         'extension.undeprecated',
         extension: @extension.name
@@ -259,7 +259,7 @@ class ExtensionsController < ApplicationController
     AdoptionMailer.delay.interest_email(@extension, current_user)
 
     redirect_to(
-      @extension,
+      owner_scoped_extension_url(@extension),
       notice: t(
         'adoption.email_sent',
         extension_or_tool: @extension.name
@@ -279,7 +279,7 @@ class ExtensionsController < ApplicationController
     @extension.update_attribute(:featured, !@extension.featured)
 
     redirect_to(
-      @extension,
+      owner_scoped_extension_url(@extension),
       notice: t(
         'extension.featured',
         extension: @extension.name,

--- a/app/controllers/transfer_ownership_controller.rb
+++ b/app/controllers/transfer_ownership_controller.rb
@@ -22,7 +22,7 @@ class TransferOwnershipController < ApplicationController
   #
   def accept
     @transfer_request.accept!
-    redirect_to @transfer_request.extension,
+    redirect_to owner_scoped_extension_url(@transfer_request.extension),
                 notice: t(
                   'extension.ownership_transfer.invite_accepted',
                   extension: @transfer_request.extension.name
@@ -36,7 +36,7 @@ class TransferOwnershipController < ApplicationController
   #
   def decline
     @transfer_request.decline!
-    redirect_to @transfer_request.extension,
+    redirect_to owner_scoped_extension_url(@transfer_request.extension),
                 notice: t(
                   'extension.ownership_transfer.invite_declined',
                   extension: @transfer_request.extension.name

--- a/app/helpers/adoption_helper.rb
+++ b/app/helpers/adoption_helper.rb
@@ -31,7 +31,12 @@ module AdoptionHelper
   # @return [String] the URL to link to
   #
   def adoption_url(obj, txt, up)
-    link_to(polymorphic_path(obj, "#{obj.class.name.downcase}" => { up_for_adoption: up }), method: :patch) do
+    path_options = {"#{obj.class.name.downcase}" => {up_for_adoption: up}}
+    if Extension === obj
+      path_options[:username] = obj.owner_name
+    end
+
+    link_to(polymorphic_path(obj, path_options), method: :patch) do
       "<i class=\"fa fa-heart\"></i> #{txt}".html_safe
     end
   end

--- a/app/helpers/collaborators_helper.rb
+++ b/app/helpers/collaborators_helper.rb
@@ -1,0 +1,10 @@
+module CollaboratorsHelper
+  def collaboration_url(resource)
+    case resource
+    when Extension
+      polymorphic_url(resource, username: resource.owner_name)
+    else
+      polymorphic_url resource
+    end
+  end
+end

--- a/app/helpers/extension_versions_helper.rb
+++ b/app/helpers/extension_versions_helper.rb
@@ -37,6 +37,7 @@ module ExtensionVersionsHelper
         extension_version_url(
           extension_version.extension,
           extension_version,
+          username: extension_version.extension.owner_name,
           anchor: 'changelog'
         )
       )

--- a/app/helpers/extensions_helper.rb
+++ b/app/helpers/extensions_helper.rb
@@ -8,8 +8,9 @@ module ExtensionsHelper
   #
   def latest_extension_version_url(extension)
     api_v1_extension_version_url(
-      extension, extension.latest_extension_version
-    )
+      extension,
+      extension.latest_extension_version,
+      username: extension.owner_name)
   end
 
   #

--- a/app/mailers/collaborator_mailer.rb
+++ b/app/mailers/collaborator_mailer.rb
@@ -1,4 +1,5 @@
 class CollaboratorMailer < ApplicationMailer
+  helper CollaboratorsHelper
 
   #
   # Creates an email to send to people when they have been added as

--- a/app/views/collaborator_mailer/added_email.html.erb
+++ b/app/views/collaborator_mailer/added_email.html.erb
@@ -1,3 +1,3 @@
 <h1>Collaborator Notification</h1>
 
-<p>You have been added as a collaborator to the <%= link_to @resource.name, polymorphic_url(@resource) %> <%= @resource.class.name %>.</p>
+<p>You have been added as a collaborator to the <%= link_to @resource.name, collaboration_url(@resource) %> <%= @resource.class.name %>.</p>

--- a/app/views/collaborator_mailer/added_email.text.erb
+++ b/app/views/collaborator_mailer/added_email.text.erb
@@ -1,4 +1,4 @@
 ManageIQ Extension Depot - Collaborator Notification
 _________________________________________________________
 
-You have been added as a collaborator to the <%= @resource.name %> <%= @resource.class.name %>.  Find out more details here: <%= polymorphic_url(@resource) %>
+You have been added as a collaborator to the <%= @resource.name %> <%= @resource.class.name %>.  Find out more details here: <%= collaboration_url(@resource) %>

--- a/app/views/extension_mailer/follower_notification_email.html.erb
+++ b/app/views/extension_mailer/follower_notification_email.html.erb
@@ -1,13 +1,24 @@
 <h1>New version of <%= @extension_version.name %> released.</h1>
 <p>A new version of <%= @extension_version.name %> has been released [<%= @extension_version.version %>].</p>
-<%= link_to 'View Version', extension_version_url(@extension_version.extension, @extension_version), class: 'button accept' %>
+<%= link_to 'View Version',
+            extension_version_url(
+                @extension_version.extension,
+                @extension_version,
+                username: @extension_version.extension.owner_name),
+            class: 'button accept' %>
 
 <div class="changelog">
   <% if @extension_version.changelog.present? %>
     <h2 class="title">Changelog</h2>
     <%= HTML_Truncator.truncate(render_document(@extension_version.changelog, @extension_version.changelog_extension), 30, ellipsis: '').html_safe %>
 
-    <%= link_to 'View Full Changelog', extension_version_url(@extension_version.extension, @extension_version, anchor: 'changelog'), class: 'button accept' %>
+    <%= link_to 'View Full Changelog',
+                extension_version_url(
+                    @extension_version.extension,
+                    @extension_version,
+                    username: @extension_version.extension.owner_name,
+                    anchor: 'changelog'),
+                class: 'button accept' %>
   <% end %>
 </div>
 

--- a/app/views/extension_mailer/follower_notification_email.text.erb
+++ b/app/views/extension_mailer/follower_notification_email.text.erb
@@ -6,7 +6,10 @@ New version of <%= @extension_version.name %> released.
 
 A new version of <%= @extension_version.name %> has been released [<%= @extension_version.version %>].
 
-<%= extension_version_url(@extension_version.extension, @extension_version) %>
+<%= extension_version_url(
+        @extension_version.extension,
+        @extension_version,
+        username: @extension_version.extension.owner_name) %>
 
 <% if @extension_version.changelog.present? %>
 Changelog
@@ -14,7 +17,11 @@ _________________________________________________________
 
 <%= truncate @extension_version.changelog, length: 100 %>
 
-<%= extension_version_url(@extension_version.extension, @extension_version, anchor: 'changelog') %>
+<%= extension_version_url(
+        @extension_version.extension,
+        @extension_version,
+        username: @extension_version.extension.owner_name,
+        anchor: 'changelog') %>
 <% end %>
 
 Unsubscribe from this email: <%= unsubscribe_url(@email_preference) %>

--- a/app/views/extensions/_sidebar.html.erb
+++ b/app/views/extensions/_sidebar.html.erb
@@ -117,7 +117,11 @@
       <i class="fa fa-download"></i> <span itemprop="interactionCount"><%= number_with_delimiter(version.try(:download_count) || 0) %></span> Downloads of Version <%= version.try(:version) %>
       <small><%= number_with_delimiter(extension.download_count) %> Total Downloads</small>
     </h4>
-    <%= link_to "Download Extension", { action: 'download' }, class: 'button primary radius expand button_download_extension' %>
+    <%= link_to "Download Extension",
+                download_extension_path(
+                    extension,
+                    username: extension.owner_name),
+                class: 'button primary radius expand button_download_extension' %>
   </div>
 
   <h4>

--- a/app/views/extensions/_sidebar.html.erb
+++ b/app/views/extensions/_sidebar.html.erb
@@ -87,7 +87,14 @@
       </ul>
     <% end %>
 
-    <%= form_tag({ controller: "extension_versions", action: "update_platforms", extension_id: extension.lowercase_name, version: version.try(:version) }, method: :put, class: "toggle-platforms-edit toggle-platforms-hidden") do %>
+    <%= form_tag({controller:   "extension_versions",
+                  action:       "update_platforms",
+                  username:     extension.owner_name,
+                  extension_id: extension.lowercase_name,
+                  version:      version.try(:version)
+                 },
+                 method: :put,
+                 class:  "toggle-platforms-edit toggle-platforms-hidden") do %>
       <ul class="extension_platforms">
         <% SupportedPlatform.all.each do |sp| %>
           <li title="<%= sp.name %>">

--- a/app/views/extensions/deprecate_search.json.jbuilder
+++ b/app/views/extensions/deprecate_search.json.jbuilder
@@ -2,5 +2,7 @@ json.items @results do |extension|
   json.extension_name extension.name
   json.extension_maintainer extension.maintainer
   json.extension_description extension.description
-  json.extension api_v1_extension_url(extension)
+  json.extension api_v1_extension_url(
+                   extension,
+                   username: extension.owner_name)
 end

--- a/app/views/extensions/show.atom.builder
+++ b/app/views/extensions/show.atom.builder
@@ -3,7 +3,13 @@ atom_feed language: 'en-US' do |feed|
   feed.updated @extension_versions.max_by(&:updated_at).try(:updated_at)
 
   @extension_versions.each do |v|
-    feed.entry(v, url: extension_version_url(@extension, v)) do |entry|
+    feed.entry(
+      v,
+      url: extension_version_url(
+             @extension,
+             v,
+             username:     @extension.owner_name)
+    ) do |entry|
       entry.title "#{v.extension.name} - v#{v.version}"
       entry.content extension_atom_content(v), type: 'html'
       entry.author do |author|

--- a/app/views/users/followed_extension_activity.atom.builder
+++ b/app/views/users/followed_extension_activity.atom.builder
@@ -3,7 +3,12 @@ atom_feed language: 'en-US' do |feed|
   feed.updated safe_updated_at(@followed_extension_activity)
 
   @followed_extension_activity.each do |extension_version|
-    feed.entry extension_version, url: extension_version_url(extension_version.extension, extension_version.version) do |entry|
+    feed.entry extension_version,
+               url: extension_version_url(
+                      extension_version.extension,
+                      extension_version,
+                      username:     extension_version.extension.owner_name
+                    ) do |entry|
       entry.title t('extension.activity',
                     maintainer: extension_version.extension.maintainer,
                     version: extension_version.version,

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -74,7 +74,7 @@ module ApiSpecHelpers
   # @param user [User] the user that's unsharing the extension version
   #
   def unshare_extension_version(extension_name, version, user)
-    extension_version_path = "/api/v1/extensions/#{extension_name}/versions/#{version}"
+    extension_version_path = api_v1_extension_version_path(username: user.username, extension: extension_name, version: version)
 
     header = Mixlib::Authentication::SignedHeaderAuth.signing_object(
       http_method: 'delete',

--- a/spec/support/api_spec_helpers.rb
+++ b/spec/support/api_spec_helpers.rb
@@ -74,7 +74,10 @@ module ApiSpecHelpers
   # @param user [User] the user that's unsharing the extension version
   #
   def unshare_extension_version(extension_name, version, user)
-    extension_version_path = api_v1_extension_version_path(username: user.username, extension: extension_name, version: version)
+    extension_version_path = api_v1_extension_version_path(
+      username:  user.username,
+      extension: extension_name,
+      version:   version)
 
     header = Mixlib::Authentication::SignedHeaderAuth.signing_object(
       http_method: 'delete',


### PR DESCRIPTION
All extension-related URLs require a `:username` component, but not all of our URL generation helpers were including that component.  This branch updates all the URL generation code to produce the correct URLs.

This branch is not expected to pass the test suite.