### PR TITLE
Dan/fix extension upload

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -24,11 +24,12 @@ class Account < ApplicationRecord
   #
   def unique_username_and_provider
     if Account.exists?(provider: provider, username: username)
-      errors[:base] << I18n.t(
-        'account.already_connected',
-        provider: provider.titleize,
-        username: username
-      )
+      errors.add(:base,
+                 I18n.t(
+                   'account.already_connected',
+                   provider: provider.titleize,
+                   username: username
+                 ))
     end
   end
 end

--- a/app/services/create_extension.rb
+++ b/app/services/create_extension.rb
@@ -45,7 +45,7 @@ class CreateExtension
       result = false
     end
 
-    if !result then extension.errors[:github_url] = I18n.t("extension.github_url_format_error") end
+    if !result then extension.errors.add(:github_url, I18n.t("extension.github_url_format_error")) end
 
     result
   end

--- a/app/views/extensions/new.html.erb
+++ b/app/views/extensions/new.html.erb
@@ -20,11 +20,11 @@
             <p id="loading-extensions"><%= image_tag "spinner.gif" %> Loading your extensions...</p>
             <p id="loading-extensions-failed" style="display: none;">Loading your extensions failed...</p>
           <% end %>
-          
-          <%= f.hidden_field :github_url, id: "extension-url-field" %>
           <% end %>
-        
+
         </div>
+
+        <%= f.hidden_field :github_url, id: "extension-url-field" %>
 
         <div class="description-field">
           <%= f.text_field :name, placeholder: "Name", title: "Name", required: true, id: "extension-name-field" %>

--- a/spec/services/create_extension_spec.rb
+++ b/spec/services/create_extension_spec.rb
@@ -73,14 +73,14 @@ describe CreateExtension do
   it "does not save and adds an error if the user is not a collaborator in the repo" do
     allow(github).to receive(:collaborator?).with("cvincent/test", "some_user") { false }
     expect(extension).not_to receive(:save)
-    expect(errors).to receive(:[]=).with(:github_url, I18n.t("extension.github_url_format_error"))
+    expect(errors).to receive(:add).with(:github_url, I18n.t("extension.github_url_format_error"))
     expect(subject.process!).to be(extension)
   end
 
   it "does not save and adds an error if the repo is invalid" do
     allow(github).to receive(:collaborator?).with("cvincent/test", "some_user").and_raise(ArgumentError)
     expect(extension).not_to receive(:save)
-    expect(errors).to receive(:[]=).with(:github_url, I18n.t("extension.github_url_format_error"))
+    expect(errors).to receive(:add).with(:github_url, I18n.t("extension.github_url_format_error"))
     expect(subject.process!).to be(extension)
   end
 end


### PR DESCRIPTION
This branch fixes an issue with the extension upload page.  The page was always failing to upload an extension because a UJS script was wiping out a needed hidden field.