### PR TITLE
Dan/simple cov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ doc/
 
 # Allow developers to have their own .rspec file
 /.rspec
+
+# SimpleCov artifacts
+/coverage
+
+# In case anyone ever develops on a Mac
+.DS_Store
+._.DS_Store

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,5 @@
+SimpleCov.start 'rails' do
+  add_filter "/vendor/"
+  add_filter "/app/channels"
+end
+SimpleCov.minimum_coverage 50  # Take this up to 100 once the dust settles

--- a/Gemfile
+++ b/Gemfile
@@ -102,14 +102,15 @@ group :test do
   gem 'rails-controller-testing'
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
-  gem 'factory_bot_rails'
-  gem 'poltergeist'
-  gem 'shoulda-matchers'
-  gem 'vcr', :require => false
-  gem 'database_cleaner'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
+  gem 'database_cleaner'
+  gem 'factory_bot_rails'
+  gem 'poltergeist'
+  gem 'selenium-webdriver'
+  gem 'shoulda-matchers'
+  gem 'simplecov', :require => false
+  gem 'vcr', :require => false
   gem 'webmock', :require => false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,7 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
+    docile (1.3.1)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -189,6 +190,7 @@ GEM
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
     jmespath (1.4.0)
+    json (2.1.0)
     jwt (1.5.6)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
@@ -425,6 +427,11 @@ GEM
       connection_pool (~> 2.2, >= 2.2.2)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 5)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -537,6 +544,7 @@ DEPENDENCIES
   sendgrid-ruby
   shoulda-matchers
   sidekiq
+  simplecov
   sitemap_generator
   spring
   spring-watcher-listen (~> 2.0.0)
@@ -555,4 +563,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe SessionsController do
+  before do
+    User.destroy_all
+  end
+
   describe 'POST #create' do
     let(:auth_hash) { OmniAuth.config.mock_auth[:github] }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,7 @@
+unless ENV['NOCOV']
+  require 'simplecov'
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
This branch adds test coverage analysis to every run of the test suite.

Our current coverage is 50.34%, so I set the failure threshold to 50%, to prevent us from getting any worse.  Over time, as we add more test coverage, we can bump up the threshold that is in the `.simplecov` file.