### PR TITLE
Dan/fix extension syncing

### DIFF
--- a/app/workers/sync_extension_contents_at_versions_worker.rb
+++ b/app/workers/sync_extension_contents_at_versions_worker.rb
@@ -20,15 +20,7 @@ class SyncExtensionContentsAtVersionsWorker < ApplicationWorker
 
     perform_next and return unless semver?
 
-    checkout_correct_tag
-    readme_body, readme_ext = fetch_readme
-    logger.info "GOT README: #{readme_body}"
-    version = ensure_updated_version(readme_body, readme_ext)
-    set_compatible_platforms(version)
-    set_last_commit(version)
-    set_commit_count(version)
-    scan_files(version)
-    version.save
+    sync_extension_version
 
     tally_commits if @tag == "master"
 
@@ -38,6 +30,18 @@ class SyncExtensionContentsAtVersionsWorker < ApplicationWorker
   end
 
   private
+
+  def sync_extension_version
+    checkout_correct_tag
+    readme_body, readme_ext = fetch_readme
+    logger.info "GOT README: #{readme_body}"
+    version = ensure_updated_version(readme_body, readme_ext)
+    set_compatible_platforms(version)
+    set_last_commit(version)
+    set_commit_count(version)
+    scan_files(version)
+    version.save
+  end
 
   def perform_next
     if @tags.any?

--- a/app/workers/sync_extension_contents_at_versions_worker.rb
+++ b/app/workers/sync_extension_contents_at_versions_worker.rb
@@ -18,11 +18,10 @@ class SyncExtensionContentsAtVersionsWorker < ApplicationWorker
     @compatible_platforms = compatible_platforms
     @run = CmdAtPath.new(@extension.repo_path)
 
-    perform_next and return unless semver?
-
-    sync_extension_version
-
-    tally_commits if @tag == "master"
+    if semver?
+      sync_extension_version
+      tally_commits if @tag == "master"
+    end
 
     perform_next
   ensure

--- a/spec/workers/sync_extension_contents_at_versions_worker_spec.rb
+++ b/spec/workers/sync_extension_contents_at_versions_worker_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe SyncExtensionContentsAtVersionsWorker do
+  let!(:extension) { create :extension }
+
+  describe 'tag checking' do
+    subject { SyncExtensionContentsAtVersionsWorker.new }
+
+    before do
+      FileUtils.mkdir_p extension.repo_path
+      allow_any_instance_of(CmdAtPath).to receive(:cmd) { "" }
+    end
+
+    it 'honors semver tags' do
+      tags = ["0.01"]   # is semver-conformant
+
+      expect {
+        subject.perform(extension.id, tags)
+      }.to change{ExtensionVersion.count}.by 1
+    end
+
+    it 'ignores non-semver tags' do
+      tags = ["v0.1-20180919"]  # is not semver-conformant
+
+      expect {
+        subject.perform(extension.id, tags)
+      }.not_to change{ExtensionVersion.count}
+    end
+  end
+end


### PR DESCRIPTION
One of the lines of Ruby code in a worker class,

```
perform_next and return unless semver?
```

was not operating as the developer probably intended.  It should have been:

```
perform_next
return unless semver?
```

The code changes in this branch produce the same effective re-write, and also include a code refactoring (for clarity) and a spec test to verify that the re-write is correct.

This PR addresses [Fix exception raised during extension syncing](https://trello.com/c/oRZkDlOd)