### PR TITLE
Fix URL generation for replacement extensions

### DIFF
--- a/app/views/extensions/_extension.html.erb
+++ b/app/views/extensions/_extension.html.erb
@@ -16,8 +16,9 @@
 
       <% if extension.deprecated? %>
         <span class="meta">
-          <% if extension.replacement.present? %>
-            <i class="fa fa-exclamation-triangle"></i> Deprecated in favor of <%= link_to extension.replacement.name, extension.replacement %>
+          <%- replacement_extension = extension.replacement %>
+          <% if replacement_extension.present? %>
+            <i class="fa fa-exclamation-triangle"></i> Deprecated in favor of <%= link_to replacement_extension.name, owner_scoped_extension_url(replacement_extension) %>
           <% else %>
             <i class="fa fa-exclamation-triangle"></i> Deprecated
           <% end %>

--- a/app/views/extensions/_main.html.erb
+++ b/app/views/extensions/_main.html.erb
@@ -2,8 +2,9 @@
   <% if extension.deprecated? %>
     <div class="deprecation-notice">
       <h2 class="deprecation-copy">
-        <% if extension.replacement.present? %>
-          <i class="fa fa-exclamation-triangle"></i> <%= extension.name %> has been deprecated in favor of <%= link_to extension.replacement.name, extension.replacement %>
+        <%- replacement_extension = extension.replacement %>
+        <% if replacement_extension.present? %>
+          <i class="fa fa-exclamation-triangle"></i> <%= extension.name %> has been deprecated in favor of <%= link_to replacement_extension.name, owner_scoped_extension_url(replacement_extension) %>
         <% else %>
           <i class="fa fa-exclamation-triangle"></i> <%= extension.name %> has been deprecated
         <% end %>


### PR DESCRIPTION
This branch fixes [Link in deprecation warning is broken](https://trello.com/c/t0Xtqi48).