### PR TITLE
Dan/delete versions

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -2,4 +2,4 @@ SimpleCov.start 'rails' do
   add_filter "/vendor/"
   add_filter "/app/channels"
 end
-SimpleCov.minimum_coverage 50  # Take this up to 100 once the dust settles
+SimpleCov.minimum_coverage 55  # Take this up to 100 once the dust settles

--- a/app/authorizers/extension_authorizer.rb
+++ b/app/authorizers/extension_authorizer.rb
@@ -104,6 +104,10 @@ class ExtensionAuthorizer < Authorizer::Base
     make_hosted_extension?
   end
 
+  def delete_hosted_extension_version?
+    add_hosted_extension_version?
+  end
+
   private
 
   def admin?

--- a/app/controllers/extension_versions_controller.rb
+++ b/app/controllers/extension_versions_controller.rb
@@ -53,6 +53,13 @@ class ExtensionVersionsController < ApplicationController
     end
   end
 
+  def destroy
+    authorize! @extension, :delete_hosted_extension_version?
+    @version.destroy
+    redirect_to owner_scoped_extension_url(@extension),
+                notice: "#{@extension.name} version #{@version.version} deleted."
+  end
+
   #
   # PUT /extension/:extension_id/versions/:version
   #

--- a/app/views/extensions/_manage_extension.html.erb
+++ b/app/views/extensions/_manage_extension.html.erb
@@ -10,6 +10,18 @@
     </li>
   <%- end %>
 
+  <%- if extension.hosted? && policy(extension).delete_hosted_extension_version? && extension.extension_versions.many? %>
+    <li>
+      <%= link_to delete_extension_version_path(extension, username: extension.owner_name, version: version),
+                  method: :delete,
+                  rel: 'delete-version',
+                  data: {confirm: "Are you sure you want to delete version #{version.version}?"} do %>
+        <i class="fa fa-trash-o"></i>
+        <span>Delete version <%= version.version %></span>
+      <% end %>
+    </li>
+  <%- end %>
+
   <% if policy(extension).transfer_ownership? %>
     <% if false %>
     <li>

--- a/app/views/extensions/_sidebar.html.erb
+++ b/app/views/extensions/_sidebar.html.erb
@@ -3,7 +3,7 @@
   <%= render 'resources/collaborators', collaborators: collaborators, resource: extension %>
 
   <% if policy(extension).manage? %>
-    <%= render "extensions/manage_extension", extension: extension %>
+    <%= render "extensions/manage_extension", extension: extension, version: version %>
   <% end %>
 
   <% if extension.up_for_adoption? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
 
   get '/extensions/:username/:extension_id/versions/:version/download' => 'extension_versions#download', as: :extension_version_download, constraints: { version: VERSION_PATTERN }
   get '/extensions/:username/:extension_id/versions/:version' => 'extension_versions#show', as: :extension_version, constraints: { version: VERSION_PATTERN }
+  delete '/extensions/:username/:extension_id/versions/:version' => 'extension_versions#destroy', as: :delete_extension_version, constraints: { version: VERSION_PATTERN }
   put "/extensions/:username/:extension_id/versions/:version/update_platforms" => "extension_versions#update_platforms", as: :extension_update_platforms, constraints: { version: VERSION_PATTERN }
 
   resources :collaborators, only: [:index, :new, :create, :destroy] do

--- a/spec/controllers/extension_versions_controller_spec.rb
+++ b/spec/controllers/extension_versions_controller_spec.rb
@@ -63,4 +63,27 @@ describe ExtensionVersionsController do
       end
     end
   end
+
+
+  describe "destroy" do
+    let!(:extension_version) { create :extension_version }
+    let(:extension)          { extension_version.extension }
+
+    let(:params) { {
+      extension_id: extension.lowercase_name,
+      username:     extension.owner_name,
+      version:      extension_version.version,
+    } }
+
+    it "destroys the requested extension version" do
+      expect {
+        delete :destroy, params: params
+      }.to change{ExtensionVersion.count}.by(-1)
+    end
+
+    it "redirects to the extension page" do
+      delete :destroy, params: params
+      expect(response).to redirect_to [extension, username: extension.owner_name]
+    end
+  end
 end


### PR DESCRIPTION
This branch completes the following Trello card:

<blockquote class="trello-card"><a href="https://trello.com/c/9YzjMGbN/71-admins-allow-asset-versions-to-be-disabled-deleted">Admins - Allow Asset Versions to be Disabled (Deleted)</a></blockquote>