### PR TITLE
Turn email requirement back on

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
 
   # Validations
   # --------------------
-  # validates_presence_of :email
+  validates_presence_of :email
 
   # Callbacks
   # --------------------


### PR DESCRIPTION
This branch completes the following Trello card:
<blockquote class="trello-card"><a href="https://trello.com/c/28Z0HI7e/65-make-email-a-required-field-for-all-user-accounts">Make email a required field for all user accounts</a></blockquote>