### PR TITLE
Dan/manual resync

### DIFF
--- a/app/authorizers/extension_authorizer.rb
+++ b/app/authorizers/extension_authorizer.rb
@@ -112,6 +112,10 @@ class ExtensionAuthorizer < Authorizer::Base
     admin?
   end
 
+  def sync_repo?
+    owner_or_admin?
+  end
+
   private
 
   def admin?

--- a/app/controllers/extensions_controller.rb
+++ b/app/controllers/extensions_controller.rb
@@ -327,6 +327,14 @@ class ExtensionsController < ApplicationController
     redirect_to owner_scoped_extension_url(@extension), notice: t("extension.reported", extension: @extension.name)
   end
 
+  def sync_repo
+    extension = Extension.with_owner_and_lowercase_name(owner_name: params[:username], lowercase_name: params[:id])
+    authorize! extension
+
+    SyncExtensionRepoWorker.perform_async(extension.id)
+    redirect_to owner_scoped_extension_url(@extension), notice: t("extension.syncing_in_progress")
+  end
+
   #
   # GET /extensions/:id/deprecate_search?q=QUERY
   #

--- a/app/views/extensions/_manage_extension.html.erb
+++ b/app/views/extensions/_manage_extension.html.erb
@@ -142,4 +142,32 @@
       <pre><%= version.config.to_yaml %></pre>
     </div>
   <% end %>
+
+  <% if !extension.hosted? && policy(extension).sync_repo? %>
+    <li>
+      <%= link_to '#', class: 'recompile', rel: 'recompile', 'data-reveal-id' => 'recompile' do %>
+        <i class="fa fa-coffee"></i>
+        Recompile releases...
+      <% end %>
+    </li>
+
+    <div id="recompile" class="reveal-modal small" data-reveal>
+      <h1>Recompile Releases</h1>
+      <a class="close-reveal-modal">&#215;</a>
+
+      <p>
+        Recompiling will update the Bonsai Asset Index with the latest information
+        about GitHub releases and release assets for this extension.
+      </p>
+
+      <div style="margin-top: 24px;" class="text-center">
+        <%= link_to "Recompile",
+                    sync_repo_extension_path(extension, username: extension.owner_name),
+                    method: :put,
+                    class: "button primary radius tiny close-reveal-modal"
+        %>
+        <a class="button secondary radius tiny close-reveal-modal">Cancel</a>
+      </div>
+    </div>
+  <% end %>
 </ul>

--- a/app/workers/sync_extension_repo_worker.rb
+++ b/app/workers/sync_extension_repo_worker.rb
@@ -2,6 +2,8 @@ class SyncExtensionRepoWorker < ApplicationWorker
 
   def perform(extension_id, compatible_platforms = [])
     @extension = Extension.find(extension_id)
+    return if @extension.hosted?
+
     releases = @extension.octokit.releases(@extension.github_repo)
 
     clone_repo

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
     disabled: "%{extension} is now disabled."
     enabled: "%{extension} is now enabled."
     reported: "%{extension} has been reported."
+    syncing_in_progress: "Please wait a minute or so for the repository releases to be recompiled, then refresh this page to see the updates."
     deprecate_with_deprecated_failure: "This extension cannot be deprecated in favor of a deprecated extension."
     activity: "%{maintainer} released v%{version} of the %{extension} extension."
     updated: "The %{name} extension has been successfully updated."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
         put :disable
         put :enable
         put :report
+        put :sync_repo
       end
     end
 

--- a/spec/controllers/extensions_controller_spec.rb
+++ b/spec/controllers/extensions_controller_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ExtensionsController do
+  let(:extension) { create :extension }
+  let(:params)    { {
+    id:       extension.lowercase_name,
+    username: extension.owner_name,
+  } }
+
+  before do
+    sign_in create(:admin)
+  end
+
+  describe "sync_repo" do
+    it 'redirects to the extension page' do
+      put :sync_repo, params: params
+      expect(response).to redirect_to [extension, username: extension.owner_name]
+    end
+
+    it 'starts a sync job' do
+      expect(SyncExtensionRepoWorker).to receive(:perform_async)
+      put :sync_repo, params: params
+    end
+  end
+end


### PR DESCRIPTION
This branch adds a new GUI control, "Recompile releases", for admins and extension owners.  The control forces the backend to re-fetch all of the metadata about an extension's GitHub releases.