### PR TITLE
Dan/misc fixes

### DIFF
--- a/app/helpers/extension_versions_helper.rb
+++ b/app/helpers/extension_versions_helper.rb
@@ -60,10 +60,10 @@ module ExtensionVersionsHelper
   #
   # @return [String] the Document content ready to be rendered
   #
-  def render_document(content, extension, repo_loc = "", version = "")
+  def render_document(content, extension, repo_loc = "", version = "", hard_wrap: false)
     doc = begin
       if %w(md mdown markdown).include?(extension.downcase)
-        render_markdown(content)
+        render_markdown(content, hard_wrap: hard_wrap)
       else
         content
       end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -36,9 +36,9 @@ module MarkdownHelper
   #
   # @return [String] escaped HTML.
   #
-  def render_markdown(text)
+  def render_markdown(text, hard_wrap: false)
     Redcarpet::Markdown.new(
-      SupermarketRenderer,
+      SupermarketRenderer.new(hard_wrap: hard_wrap),
       autolink: true,
       fenced_code_blocks: true,
       tables: true,

--- a/app/models/extension.rb
+++ b/app/models/extension.rb
@@ -482,7 +482,9 @@ class Extension < ApplicationRecord
   private
 
   #
-  # Populates the +lowercase_name+ attribute with the lowercase +name+
+  # Populates the +lowercase_name+ attribute.
+  #
+  # Prefers to use the GitHub repo name, or if that is not available, use the lowercase +name+.be
   #
   # This exists until Rails schema dumping supports Posgres's expression
   # indices, which would allow us to create an index on LOWER(name). To do that
@@ -490,7 +492,7 @@ class Extension < ApplicationRecord
   # less-than ideal
   #
   def copy_name_to_lowercase_name
-    self.lowercase_name = name.to_s.downcase.parameterize
+    self.lowercase_name = File.basename(self.github_url.to_s).presence || name.to_s.downcase.parameterize
   end
 
   #

--- a/app/views/api/v1/extensions/_extension.json.jbuilder
+++ b/app/views/api/v1/extensions/_extension.json.jbuilder
@@ -1,4 +1,4 @@
-json.name         [extension.owner_name, extension.name].join('/')
+json.name         [extension.owner_name, extension.lowercase_name].join('/')
 json.description  extension.description
 json.url          api_v1_extension_url(extension, username: extension.owner_name)
 json.github_url   extension.github_url

--- a/app/views/extensions/_release_notes.html.erb
+++ b/app/views/extensions/_release_notes.html.erb
@@ -1,1 +1,1 @@
-<%= render_document(version.release_notes.presence || "No release notes are available.", "md") %>
+<%= render_document(version.release_notes.presence || "No release notes are available.", "md", hard_wrap: true) %>

--- a/spec/factories/extension.rb
+++ b/spec/factories/extension.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     issues_url { 'http://example.com/issues' }
     deprecated { false }
     featured { false }
-    github_url { "https://github.com/tester/testing" }
+    sequence(:github_url) { |n| "https://github.com/tester/testing#{n}" }
 
     transient do
       extension_versions_count { 2 }

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -42,6 +42,15 @@ wrap.
     expect(helper.render_markdown(markdown)).to_not match(/<br>/)
   end
 
+  it "does add br tags on hard wraps if asked to" do
+    markdown = <<-EOH
+There is no hard
+wrap.
+    EOH
+
+    expect(helper.render_markdown(markdown, hard_wrap: true)).to match(/<br>/)
+  end
+
   it "doesn't emphasize underscored words" do
     expect(helper.render_markdown('some_long_method_name')).to_not match(/<em>/)
   end

--- a/spec/services/create_extension_spec.rb
+++ b/spec/services/create_extension_spec.rb
@@ -21,7 +21,7 @@ describe CreateExtension do
   subject { CreateExtension.new(params, user) }
   let(:normalized_attributes) { {
     'github_url'     => "https://github.com/#{github_url}",
-    'lowercase_name' => "asdf",
+    'lowercase_name' => "test",
   } }
   let(:expected_unnormalized_attributes) { Extension.new(params.merge(owner: user)).attributes }
   let(:expected_normalized_attributes)   { Extension.new(params.merge(owner: user)).attributes.merge(normalized_attributes) }


### PR DESCRIPTION
Two fixes:

1. fixed the release note parsing so that it hard-wraps newlines
2. made the lowercase name for new extensions prefer to be the GitHub repo name, if available.